### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -79,7 +79,7 @@ All contributions and suggestions are welcome.
     :target: https://pypi.python.org/pypi/mongrey
     :alt: License
 
-.. |pypi wheel| image:: https://pypip.in/wheel/mongrey/badge.png
+.. |pypi wheel| image:: https://img.shields.io/pypi/wheel/mongrey.svg
     :target: https://pypi.python.org/pypi/mongrey/
     :alt: Python Wheel
         


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20mongrey))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `mongrey`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badge to use shields.io instead.